### PR TITLE
Add support for query string cache busting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "joseym/li3_frontender",
+	"name": "brandonwestcott/li3_frontender",
 	"type": "li3-libraries",
 	"description": "Lithium PHP asset extension",
 	"keywords": ["styles", "assets", "compression", "js", "lithium", "li3"],

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -23,7 +23,7 @@ defined('FRONTENDER_VENDORS') OR define('FRONTENDER_VENDORS', FRONTENDER_PATH . 
 defined('FRONTENDER_LIBS') OR define('FRONTENDER_LIBS', FRONTENDER_PATH . "/libraries");
 defined('FRONTENDER_SRC') OR define('FRONTENDER_SRC', FRONTENDER_LIBS . "/assetic/src/Assetic");
 
-defined('CACHE_DIR') OR define('CACHE_DIR', Libraries::get(true, 'resources') . "/tmp/cache");
+defined('FRONTENDER_WEBROOT_DIR') OR define('FRONTENDER_WEBROOT_DIR', __DIR__ . "/../../../webroot");
 
 /**
  * Load in project dependancies which include

--- a/extensions/helper/Assets.php
+++ b/extensions/helper/Assets.php
@@ -175,7 +175,7 @@ class Assets extends \lithium\template\Helper {
 
 			}
 
-			$filename .= $path;
+			$filename .= $file;
 
 			// add asset to assetic collection
 			$this->{$type}->add( 

--- a/extensions/helper/Assets.php
+++ b/extensions/helper/Assets.php
@@ -267,21 +267,21 @@ class Assets extends \lithium\template\Helper {
 
 
 		// loop thru cache and delete old cache file
-		 if (!$this->_production && $handle = opendir($cache_location)) {
+		if (!$this->_production && $handle = opendir($cache_location)) {
 
-			 while (false !== ($oldfile = readdir($handle))) {
+			while (false !== ($oldfile = readdir($handle))) {
 			
-				 if(preg_match("/^{$like_files}/", $oldfile)){
+				if(preg_match("/^{$like_files}/", $oldfile)){
 
-					 unlink("{$options['location']}/{$oldfile}");
+					unlink("{$options['location']}/{$oldfile}");
 
-				 }
+				}
 
-			 }
+			}
 
-			 closedir($handle);
+			closedir($handle);
 
-		 }
+		}
 
 		file_put_contents("{$cache_location}/{$filename}", $content);
 

--- a/extensions/helper/Assets.php
+++ b/extensions/helper/Assets.php
@@ -5,7 +5,6 @@ namespace li3_frontender\extensions\helper;
 use RuntimeException;
 use \lithium\core\Environment;
 use \lithium\core\Libraries;
-use \lithium\storage\Cache;
 use \lithium\util\String;
 
 // Assetic Classes
@@ -226,16 +225,17 @@ class Assets extends \lithium\template\Helper {
 		// ---
 		// If you change a file in the styles added then a recache is made due
 		// to the fact that the file stats changed
-		if(!$cached = Cache::read('default', "{$options['type']}/{$filename}")){
+		$cached_path = FRONTENDER_WEBROOT_DIR . "/{$options['type']}/compiled/{$filename}";
+		if(!file_exists($cached_path) || !$cached = file_get_contents($cached_path)){
 			$this->setCache($filename, $content->dump(), array('location' => $options['type']));			
 		}
 
 		// pass single stylesheet link
 		switch($options['type']){
 			case 'css':
-				return $this->_context->helper('html')->style("{$filename}") . "\n\t";
+				return $this->_context->helper('html')->style("compiled/{$filename}") . "\n\t";
 			case 'js':
-				return $this->_context->helper('html')->script("{$filename}") . "\n\t";
+				return $this->_context->helper('html')->script("compiled/{$filename}") . "\n\t";
 		}
 
 	}
@@ -249,7 +249,8 @@ class Assets extends \lithium\template\Helper {
 	private function setCache($filename, $content, $options = array()){
 
 		// Create css cache dir if it doesnt exist.
-		if (!is_dir($cache_location = CACHE_DIR . "/{$options['location']}")) {
+		// FIXME This is janky
+		if (!is_dir($cache_location = FRONTENDER_WEBROOT_DIR . "/" . $options['location'] . "/compiled")) {
 			mkdir($cache_location, 0755, true);
 		}
 
@@ -272,7 +273,7 @@ class Assets extends \lithium\template\Helper {
 			
 				 if(preg_match("/^{$like_files}/", $oldfile)){
 
-					 Cache::delete('default', "{$options['location']}/{$oldfile}");
+					 unlink("{$options['location']}/{$oldfile}");
 
 				 }
 
@@ -282,7 +283,7 @@ class Assets extends \lithium\template\Helper {
 
 		 }
 
-		Cache::write('default', "{$options['location']}/{$filename}", $content, $options['length']);
+		file_put_contents("{$cache_location}/{$filename}", $content);
 
 	}
 

--- a/extensions/helper/Assets.php
+++ b/extensions/helper/Assets.php
@@ -273,7 +273,7 @@ class Assets extends \lithium\template\Helper {
 			
 				if(preg_match("/^{$like_files}/", $oldfile)){
 
-					unlink("{$options['location']}/{$oldfile}");
+					file_exists("{$options['location']}/{$oldfile}") && unlink("{$options['location']}/{$oldfile}");
 
 				}
 


### PR DESCRIPTION
Needed a way to do query string cache busting compared to file name. Had an issue with multiple servers and caching different filenames.

Added queryString option to config to allow this option.

Tested and working.
